### PR TITLE
remove unnecessary inputs for pnpm/action-setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,8 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
-        with:
-          version: 8
       - name: Setup node
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
-        with:
-          version: 8
       - name: Setup node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
`packageManager`フィールドが`package.json`にあるので不要です。
ref: https://github.com/pnpm/action-setup/blob/v3.0.0/README.md#version
