### PR TITLE
export OM_SYRINX_VERSION from package.json

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -12,6 +12,8 @@ export type {
   SyrinxConfig,
 } from "./native";
 
+export const OM_SYRINX_VERSION: string;
+
 import type { Readable } from "node:stream";
 import type { SyrinxConfig, SynthesisOption } from "./native";
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,9 @@ exports.EncoderType = EncoderType;
 exports.Channels = Channels;
 exports.Application = Application;
 
+const { version: OM_SYRINX_VERSION } = require("../package.json");
+exports.OM_SYRINX_VERSION = OM_SYRINX_VERSION;
+
 class SyrinxStream extends Readable {
   /**
    * @param {import("./native").Syrinx} syrinx

--- a/test/index.js
+++ b/test/index.js
@@ -17,8 +17,13 @@ const {
 } = require("../lib");
 const tar = require("tar-fs");
 const TOML = require("@iarna/toml");
+const { OM_SYRINX_VERSION } = require("../lib");
 
 describe("version", () => {
+  it("should match the version of om-syrinx", () => {
+    assert.strictEqual(require("../package.json").version, OM_SYRINX_VERSION);
+  });
+
   const lockFile = fs.readFileSync("Cargo.lock", "utf-8");
   const { package } = TOML.parse(lockFile);
 

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ const { pipeline } = require("node:stream/promises");
 const { setTimeout } = require("node:timers/promises");
 const crypto = require("node:crypto");
 const {
+  OM_SYRINX_VERSION,
   JPREPROCESS_VERSION,
   JBONSAI_VERSION,
   Syrinx,
@@ -17,7 +18,6 @@ const {
 } = require("../lib");
 const tar = require("tar-fs");
 const TOML = require("@iarna/toml");
-const { OM_SYRINX_VERSION } = require("../lib");
 
 describe("version", () => {
   it("should match the version of om-syrinx", () => {


### PR DESCRIPTION
CARGO_PKG_VERSIONではなくpackage.jsonを使ったのは，主にindex.jsのSyrinxStreamなど，Cargoの範疇外だがnpmの範疇内であるような部分があるためです．