### PR TITLE
refactor: replace repeat().take() with repeat_n() in PCM encoder

### DIFF
--- a/src/encoder/pcm.rs
+++ b/src/encoder/pcm.rs
@@ -28,7 +28,7 @@ impl PcmEncoder {
     }
 
     self.speech.iter().take(generated).flat_map(|f| {
-      iter::repeat(f.clamp(i16::MIN as f64, i16::MAX as f64) as i16).take(self.channels as usize)
+      iter::repeat_n(f.clamp(i16::MIN as f64, i16::MAX as f64) as i16, self.channels as usize)
     })
   }
 }


### PR DESCRIPTION
Replace manual repeat-take pattern with more concise repeat_n() function in PCM audio sample generation.
This change follows Clippy's suggestion while maintaining the same functionality.
https://rust-lang.github.io/rust-clippy/rust-1.86.0/index.html#manual_repeat_n
